### PR TITLE
Add ChatML message JSON schema

### DIFF
--- a/specs/chatml-schema.json
+++ b/specs/chatml-schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ChatML Message",
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "content": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "required": ["role", "name", "content"]
+}


### PR DESCRIPTION
Adds a new JSON schema for ChatML messages in the `specs` directory.
- Creates the `specs` directory at the root of the repository and adds a file named `chatml-schema.json`.
- Defines a JSON schema with properties `role`, `name`, and `content`, marking them as required.
- Specifies `role` and `name` as strings, and `content` can be either a string or an object, ensuring flexibility in message content representation.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/julep-ai/standard-chatml?shareId=9734a2d8-311e-457e-a29f-c9f1761b92f8).

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f6ed29c5a7720c7d7596680d6281038ac434599e  | 
|--------|

### Summary:
Adds a JSON schema for ChatML messages in a new `specs` directory, defining required properties and flexible content representation.

**Key points**:
- Creates `specs/chatml-schema.json`.
- Defines JSON schema for ChatML messages.
- Required properties: `role`, `name`, `content`.
- `content` can be string or object.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
