### PR TITLE
Fix ajv command in validate-jsonschema.yml

### DIFF
--- a/.github/workflows/validate-jsonschema.yml
+++ b/.github/workflows/validate-jsonschema.yml
@@ -26,4 +26,4 @@ jobs:
         run: npm install -g ajv-cli
 
       - name: Validate JSON Schema files
-        run: ajv validate -s specs/*.json -r specs/*.json
+        run: ajv compile -s specs/*.json


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bd9d6df78ccab8e3efdba8f8396c6c87070bd456  | 
|--------|

### Summary:
Updated the AJV command in the GitHub Actions workflow to compile JSON schemas instead of validating them.

**Key points**:
- Updated command in `.github/workflows/validate-jsonschema.yml` from `ajv validate` to `ajv compile`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
